### PR TITLE
fix: send SIGTERM to wineserver on container stop

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -59,7 +59,7 @@ shutdown_server() {
   LogAction "Attempting graceful server shutdown"
 
   local pid
-  pid=$(pgrep -f "wineserver64" | head -1)
+  pid=$(pgrep -x "wineserver" | head -1)
 
   if [ -n "$pid" ]; then
     kill -SIGTERM "$pid"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -41,11 +41,8 @@ chown -R steam:steam /home/steam/server-files
 # shellcheck disable=SC2317
 term_handler() {
     if ! shutdown_server; then
-        local pid
-        pid=$(pgrep -f "wineserver64" | head -1)
-        if [ -n "$pid" ]; then
-            kill -SIGTERM "$pid"
-        fi
+        LogWarn "Server did not shutdown gracefully, forcing shutdown"
+        wineserver -k 2>/dev/null || true
     fi
     sleep 2
     tail --pid="$killpid" -f 2>/dev/null


### PR DESCRIPTION
Match the wineserver process exactly by replacing `pgrep -f "wineserver64"` with `pgrep -x "wineserver"` in scripts/functions.sh, and simplify the fallback in scripts/init.sh by logging a warning and invoking `wineserver -k` (stderr suppressed, errors ignored) instead of manually grepping and sending SIGTERM. This ensures correct process matching and relies on wineserver's own shutdown mechanism for a cleaner termination.

Fixes #34