### PR TITLE
feat: add WINDROSE_PLUS_URL and WINDROSE_PLUS_AUTOUPDATE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,5 +24,12 @@ UE4SS_ENABLED=false
 WINDROSE_PLUS_ENABLED=false
 # Leave empty to use the version baked into the image
 WINDROSE_PLUS_VERSION=
+# Custom download URL for the Windrose+ release zip. Leave empty to use the
+# upstream GitHub release matching WINDROSE_PLUS_VERSION. Bump
+# WINDROSE_PLUS_VERSION to force a re-pull from this URL.
+WINDROSE_PLUS_URL=
+# Set to false to keep the installed version across restarts (skips update on
+# boot but still loads Windrose+).
+WINDROSE_PLUS_AUTOUPDATE=true
 WINDROSE_PLUS_DASHBOARD_PORT=8780
 WINDROSE_PLUS_RCON_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ RCON password, admin Steam IDs, and feature flags are re-read live from `windros
 |----------|---------|-------------|
 | `WINDROSE_PLUS_ENABLED` | `false` | Set to `true` to enable the addon. Automatically enables UE4SS. |
 | `WINDROSE_PLUS_VERSION` | baked-in default | GitHub release tag of Windrose+ to install. Leave empty for the image default. |
+| `WINDROSE_PLUS_URL` | | Custom download URL for the Windrose+ release zip. When set, replaces the GitHub release lookup — useful for self-hosted forks or builds. `WINDROSE_PLUS_VERSION` is still used as the install marker, so bump it to force a re-pull. |
+| `WINDROSE_PLUS_AUTOUPDATE` | `true` | Set to `false` to keep whatever version is currently on disk across restarts. Windrose+ still loads on startup; the install/update step is skipped once a version is installed. |
 | `WINDROSE_PLUS_DASHBOARD_PORT` | `8780` | Port the web dashboard listens on inside the container. |
 | `WINDROSE_PLUS_RCON_PASSWORD` | (empty → random) | Dashboard login password. Only applied when `windrose_plus.json` does not exist yet. |
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ RCON password, admin Steam IDs, and feature flags are re-read live from `windros
 |----------|---------|-------------|
 | `WINDROSE_PLUS_ENABLED` | `false` | Set to `true` to enable the addon. Automatically enables UE4SS. |
 | `WINDROSE_PLUS_VERSION` | baked-in default | GitHub release tag of Windrose+ to install. Leave empty for the image default. |
-| `WINDROSE_PLUS_URL` | | Custom download URL for the Windrose+ release zip. When set, replaces the GitHub release lookup — useful for self-hosted forks or builds. `WINDROSE_PLUS_VERSION` is still used as the install marker, so bump it to force a re-pull. |
+| `WINDROSE_PLUS_URL` | | Custom download URL for the Windrose+ release zip. When set, replaces the GitHub release lookup — useful for self-hosted forks or builds. `WINDROSE_PLUS_VERSION` is still used as the install marker, so bump it to force a re-pull. Set `WINDROSE_PLUS_VERSION=latest` together with `WINDROSE_PLUS_URL` to treat the URL as a rolling release (re-pulled on every boot). |
 | `WINDROSE_PLUS_AUTOUPDATE` | `true` | Set to `false` to keep whatever version is currently on disk across restarts. Windrose+ still loads on startup; the install/update step is skipped once a version is installed. |
 | `WINDROSE_PLUS_DASHBOARD_PORT` | `8780` | Port the web dashboard listens on inside the container. |
 | `WINDROSE_PLUS_RCON_PASSWORD` | (empty → random) | Dashboard login password. Only applied when `windrose_plus.json` does not exist yet. |

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -31,6 +31,8 @@ if [ "${WINDROSE_PLUS_ENABLED:-false}" = "true" ]; then
     LogAction "Installing/updating Windrose+"
     export WINDROSE_PLUS_VERSION="${WINDROSE_PLUS_VERSION:-$WINDROSE_PLUS_VERSION_DEFAULT}"
     export WINDROSE_PLUS_RCON_PASSWORD="${WINDROSE_PLUS_RCON_PASSWORD:-}"
+    export WINDROSE_PLUS_URL="${WINDROSE_PLUS_URL:-}"
+    export WINDROSE_PLUS_AUTOUPDATE="${WINDROSE_PLUS_AUTOUPDATE:-true}"
     SERVER_FILES=/home/steam/server-files /home/steam/server/install_windrose_plus.sh
 else
     LogInfo "Windrose+ disabled (set WINDROSE_PLUS_ENABLED=true to enable)"

--- a/scripts/install_windrose_plus.sh
+++ b/scripts/install_windrose_plus.sh
@@ -7,6 +7,13 @@
 #   WINDROSE_PLUS_ENABLED            (default false) — gate
 #   WINDROSE_PLUS_VERSION            (default $WINDROSE_PLUS_VERSION_DEFAULT)
 #   WINDROSE_PLUS_VERSION_DEFAULT    (set by the Docker image)
+#   WINDROSE_PLUS_URL                (optional) — custom download URL for the
+#                                    release zip. Skips the GitHub release lookup.
+#                                    WINDROSE_PLUS_VERSION is still used as the
+#                                    install marker, so bump it to force a re-pull.
+#   WINDROSE_PLUS_AUTOUPDATE         (default true) — when false, skip the install
+#                                    step entirely once a version is on disk. The
+#                                    server still loads whatever is already there.
 #   WINDROSE_PLUS_RCON_PASSWORD      (optional) — seeds windrose_plus.json on first run
 #   SERVER_FILES                     (default /home/steam/server-files)
 #
@@ -18,6 +25,8 @@ set -euo pipefail
 : "${SERVER_FILES:=/home/steam/server-files}"
 : "${WINDROSE_PLUS_VERSION_DEFAULT:=}"
 : "${WINDROSE_PLUS_VERSION:=$WINDROSE_PLUS_VERSION_DEFAULT}"
+: "${WINDROSE_PLUS_URL:=}"
+: "${WINDROSE_PLUS_AUTOUPDATE:=true}"
 
 if [ "$WINDROSE_PLUS_ENABLED" != "true" ]; then
     exit 0
@@ -28,7 +37,9 @@ if [ -z "$WINDROSE_PLUS_VERSION" ]; then
     exit 1
 fi
 
-if [ "$WINDROSE_PLUS_VERSION" = "latest" ]; then
+# Resolve "latest" via the GitHub API only when no custom URL is set — with a
+# custom URL the version string is just an opaque marker label.
+if [ -z "$WINDROSE_PLUS_URL" ] && [ "$WINDROSE_PLUS_VERSION" = "latest" ]; then
     WINDROSE_PLUS_VERSION=$(curl -fsSL "https://api.github.com/repos/humangenome/WindrosePlus/releases/latest" | jq -r '.tag_name')
 fi
 
@@ -43,6 +54,13 @@ if [ -n "${WINDROSE_PLUS_RCON_PASSWORD:-}" ] && [ -f "$CFG" ]; then
     chown steam:steam "$CFG" 2>/dev/null || true
 fi
 
+# Autoupdate disabled: keep whatever is on disk once a marker exists. First-run
+# installs still proceed so the server has something to load.
+if [ "$WINDROSE_PLUS_AUTOUPDATE" != "true" ] && [ -f "$MARKER" ]; then
+    echo "install_windrose_plus: WINDROSE_PLUS_AUTOUPDATE=false — keeping installed version $(cat "$MARKER")"
+    exit 0
+fi
+
 if [ -f "$MARKER" ] && [ "$(cat "$MARKER")" = "$WINDROSE_PLUS_VERSION" ]; then
     exit 0
 fi
@@ -54,6 +72,9 @@ trap 'rm -rf "$TMPDIR"' EXIT
 RELEASE_ZIP=""
 if [ -n "${WINDROSE_PLUS_ZIP_OVERRIDE:-}" ]; then
     RELEASE_ZIP="$WINDROSE_PLUS_ZIP_OVERRIDE"
+elif [ -n "$WINDROSE_PLUS_URL" ]; then
+    RELEASE_ZIP="$TMPDIR/WindrosePlus.zip"
+    curl -fsSL "$WINDROSE_PLUS_URL" -o "$RELEASE_ZIP"
 else
     RELEASE_ZIP="$TMPDIR/WindrosePlus.zip"
     curl -fsSL \

--- a/scripts/install_windrose_plus.sh
+++ b/scripts/install_windrose_plus.sh
@@ -33,14 +33,16 @@ if [ "$WINDROSE_PLUS_ENABLED" != "true" ]; then
 fi
 
 if [ -z "$WINDROSE_PLUS_VERSION" ]; then
-    echo "install_windrose_plus: WINDROSE_PLUS_VERSION is empty and no default is set" >&2
+    echo "install_windrose_plus: WINDROSE_PLUS_VERSION must be set — it's used as the install marker even when WINDROSE_PLUS_URL is provided" >&2
     exit 1
 fi
 
 # Resolve "latest" via the GitHub API only when no custom URL is set — with a
-# custom URL the version string is just an opaque marker label.
+# custom URL the version string is treated as a rolling-release marker (always
+# reinstall, see below).
 if [ -z "$WINDROSE_PLUS_URL" ] && [ "$WINDROSE_PLUS_VERSION" = "latest" ]; then
-    WINDROSE_PLUS_VERSION=$(curl -fsSL "https://api.github.com/repos/humangenome/WindrosePlus/releases/latest" | jq -r '.tag_name')
+    WINDROSE_PLUS_VERSION=$(curl -fsSL --proto =https,http --max-time 180 \
+        "https://api.github.com/repos/humangenome/WindrosePlus/releases/latest" | jq -r '.tag_name')
 fi
 
 MARKER="$SERVER_FILES/.windroseplus_version"
@@ -61,7 +63,12 @@ if [ "$WINDROSE_PLUS_AUTOUPDATE" != "true" ] && [ -f "$MARKER" ]; then
     exit 0
 fi
 
-if [ -f "$MARKER" ] && [ "$(cat "$MARKER")" = "$WINDROSE_PLUS_VERSION" ]; then
+# Custom URL with VERSION=latest is treated as a rolling release: always
+# reinstall (subject to AUTOUPDATE above) so each boot pulls a fresh zip.
+# Otherwise the marker pins to the previous version string.
+if [ -n "$WINDROSE_PLUS_URL" ] && [ "$WINDROSE_PLUS_VERSION" = "latest" ]; then
+    : # rolling — fall through to install
+elif [ -f "$MARKER" ] && [ "$(cat "$MARKER")" = "$WINDROSE_PLUS_VERSION" ]; then
     exit 0
 fi
 
@@ -74,10 +81,10 @@ if [ -n "${WINDROSE_PLUS_ZIP_OVERRIDE:-}" ]; then
     RELEASE_ZIP="$WINDROSE_PLUS_ZIP_OVERRIDE"
 elif [ -n "$WINDROSE_PLUS_URL" ]; then
     RELEASE_ZIP="$TMPDIR/WindrosePlus.zip"
-    curl -fsSL "$WINDROSE_PLUS_URL" -o "$RELEASE_ZIP"
+    curl -fsSL --proto =https,http --max-time 180 "$WINDROSE_PLUS_URL" -o "$RELEASE_ZIP"
 else
     RELEASE_ZIP="$TMPDIR/WindrosePlus.zip"
-    curl -fsSL \
+    curl -fsSL --proto =https,http --max-time 180 \
         "https://github.com/humangenome/WindrosePlus/releases/download/${WINDROSE_PLUS_VERSION}/WindrosePlus.zip" \
         -o "$RELEASE_ZIP"
 fi


### PR DESCRIPTION
Allow operators to point Windrose+ at a custom release zip and to pin the on-disk version across restarts without disabling the addon.