### PR TITLE
fix: shutdown wine as prefix owner, tag log source

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -36,7 +36,11 @@ Log() {
   local color="$2"
   local prefix="$3"
   local suffix="$4"
-  printf "$color%s$RESET$LINE" "$prefix$message$suffix"
+
+  local src
+  src=$(basename "${BASH_SOURCE[-1]}")
+
+  printf "$color%s$RESET$LINE" "[$src] $prefix$message$suffix"
 }
 
 install() {
@@ -55,31 +59,28 @@ install() {
 # Returns 0 if it is shutdown
 # Returns 1 if it is not able to be shutdown
 shutdown_server() {
-  local return_val=0
   LogAction "Attempting graceful server shutdown"
 
   local pid
   pid=$(pgrep -x "wineserver" | head -1)
-
-  if [ -n "$pid" ]; then
-    kill -SIGTERM "$pid"
-
-    local count=0
-    while [ $count -lt 30 ] && kill -0 "$pid" 2>/dev/null; do
-      sleep 1
-      count=$((count + 1))
-    done
-
-    if kill -0 "$pid" 2>/dev/null; then
-      LogWarn "Server did not shutdown gracefully, forcing shutdown"
-      return_val=1
-    else
-      LogSuccess "Server shutdown gracefully"
-    fi
-  else
-    LogWarn "Server process not found"
-    return_val=1
+  if [ -z "$pid" ]; then
+    LogWarn "Server process is not running"
+    return 1
   fi
 
-  return "$return_val"
+  # wineserver -k sends SIGINT (triggers shutdown_master_socket()), then SIGKILL,
+  # if needed, and returns once wineserver has exited.
+  # Must run as the user that owns the wineprefix, so wineserver can find the socket.
+  if ! su steam -c 'WINEPREFIX=/home/steam/.wine wineserver -k' > /dev/null 2>&1; then
+    LogWarn "wineserver -k returned non-zero"
+  fi
+
+  # Sanity check, wineserver should not be alive at this point due to wineserver -k.
+  if kill -0 "$pid" 2>/dev/null; then
+    LogWarn "wineserver still present after -k"
+    return 1
+  fi
+
+  LogSuccess "Server shutdown gracefully"
+  return 0
 }

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -42,10 +42,10 @@ chown -R steam:steam /home/steam/server-files
 term_handler() {
     if ! shutdown_server; then
         LogWarn "Server did not shutdown gracefully, forcing shutdown"
-        wineserver -k 2>/dev/null || true
+        su steam -c 'WINEPREFIX=/home/steam/.wine wineserver -k9' >/dev/null 2>&1 || true
     fi
     sleep 2
-    tail --pid="$killpid" -f 2>/dev/null
+    tail --pid="$killpid" -f /dev/null 2>/dev/null
 }
 
 trap 'term_handler' SIGTERM

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -43,6 +43,8 @@ term_handler() {
     if ! shutdown_server; then
         LogWarn "Server did not shutdown gracefully, forcing shutdown"
         su steam -c 'WINEPREFIX=/home/steam/.wine wineserver -k9' >/dev/null 2>&1 || true
+        # Anything belonging to steam is part of a dead wine session.
+        pkill -9 -u steam 2>/dev/null || true
     fi
     sleep 2
     tail --pid="$killpid" -f /dev/null 2>/dev/null


### PR DESCRIPTION
Follow-up to #43. Feel free to squash merge this, if accepted.

While the wineserver process was properly addressed there and is now terminated, it looks like Docker was still exiting with 137 due to the grace period time always timing out.

Unsure if Windrose has a true graceful shutdown hook to which wineserver can invoke. However, the following changes ensures wineserver is properly terminated by the following:

- Run the kill as steam.
- Drop the polling loop with a constant number as grace time is already set and Dockerfile has a default value if not overridden. Also, `wineserver -k` already escalates SIGINT to SIGKILL internally, so its return implies wineserver is gone.
- Follow `/dev/null` in the trap's tail so --pid works.
- Prefix log source for clarity.

Originally didn't catch the weird behaviour since I just confirmed in the logs and looked for successful shutdown, but noticed the shutdown was taking too long and always mirrored the grace period time. This time, I did the following tests:

- Built a local Docker image based on the proposed changes.
- Deployed the local image.
- Stopped the docker server.
- Verified logs were successful and observed much quicker end times.
- Did a "dummy" return 1 in `shutdown_server`, ensured forceful termination also worked.

Fixes #56
Fixes #71 